### PR TITLE
Specify nom crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "1.0.2"
 authors = ["Nikolaj Schlej <schlej@live.de>"]
 
 [dependencies]
-nom = { git = "https://github.com/Geal/nom" }
+nom = "4.2"


### PR DESCRIPTION
The master branch of nom contains breaking changes which prevent
compilation. Use the latest stable release instead.